### PR TITLE
Add link feature

### DIFF
--- a/app/controllers/admin/events_controller.rb
+++ b/app/controllers/admin/events_controller.rb
@@ -1,6 +1,6 @@
 class Admin::EventsController < ApplicationController
   before_action :require_login
-  
+
   def new
     @event = Event.new
   end
@@ -26,6 +26,6 @@ class Admin::EventsController < ApplicationController
   private
 
   def event_params
-    params.require(:event).permit(:title, :description, :start_date, :end_date, :image_url, :location, :event_type)
+    params.require(:event).permit(:title, :description, :start_date, :end_date, :image_url, :location, :event_type, :link)
   end
 end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -1,5 +1,6 @@
 class Event < ActiveRecord::Base
   validates :title, :description, :start_date, :end_date, :location, :event_type, presence: :true
+  validates_format_of :link, :with => /\A(http(s?):\/\/www.){1}.+(.com){1}/, :message => "The link is invalid."
 
   TYPES = %w(Event Workshop).freeze
 

--- a/app/views/admin/events/new.html.slim
+++ b/app/views/admin/events/new.html.slim
@@ -7,6 +7,7 @@ section
     = f.input :end_date, order: [:day, :month, :year]
     = f.input :image_url
     = f.input :location
+    = f.input :link
     = f.input :event_type do
         = f.select :event_type, { Event: 0, Workshop: 1 }
     = f.submit

--- a/app/views/dashboard/index.html.slim
+++ b/app/views/dashboard/index.html.slim
@@ -9,10 +9,12 @@ section.half
       th ID
       th Title
       th Type
+      th Link
       th Actions
     - @events.each do |event|
       tr
         td= event.id
         td= event.title
         td= event.readable_event_type
+        td= link_to(event.link, event.link, target: "_blank")
         td= link_to "Delete", admin_event_path(event.id), method: :delete, data: { confirm: "Are you sure you want to delete this event?" }

--- a/app/views/main/_event_item.html.slim
+++ b/app/views/main/_event_item.html.slim
@@ -5,3 +5,5 @@
   p = item.description
   - if item.image_url
     = image_tag item.image_url
+  - if item.link
+    = link_to(item.link, item.link, target:"_blank")

--- a/db/migrate/20170921121633_add_link_to_event.rb
+++ b/db/migrate/20170921121633_add_link_to_event.rb
@@ -1,0 +1,5 @@
+class AddLinkToEvent < ActiveRecord::Migration[5.0]
+  def change
+    add_column :events, :link, :string
+  end
+end


### PR DESCRIPTION
1. Add link field on the event creation page and verify the link using the regular expression. 
    The link must follow the pattern below:
    http://www.x.com or https://www.x.com 
2. Show the event link in the admin page and main home page